### PR TITLE
style: header menu mobile which has submenu overlap with bottom menu

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -452,6 +452,10 @@ span.fi {
   transform: scale(1.05);
 }
 
+.menu-drodpown-content {
+  z-index: 9;
+}
+
 /* Responsives */
 @media screen and (max-width: 768px) {
   .img-editor {


### PR DESCRIPTION
Found an issue on the header menu mobile which has a submenu (e.g. Enterprise -> Safety, Learn -> Blog), the menu label text overlaps with the bottom menu, see the image below

<img width="361" alt="Screenshot 2023-07-04 at 12 02 09" src="https://github.com/q6a/website-2022/assets/21036432/85b6f2c7-b980-4ba0-a9dc-4da0902f4cdf">
